### PR TITLE
Fixed portfolio link

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Full-Stack Web Developer with a passionate background in humanitarian and envr
 
 💻 I **love** coding
 
-📲 I’m currently working on a Crypto-currency App! But, check out my portfolio [here](https://www.mmeurer00.github.io)!
+📲 I’m currently working on a Crypto-currency App! But, check out my portfolio [here](https://mmeurer00.github.io)!
 
 🌱 I’m currently learning scraping methods.
 


### PR DESCRIPTION
Hello!

I came across your profile readme and noticed the link to your portfolio site lead to a 404 error. This is caused by including `www.` in the link URL and this PR fixes that. 

Note: the diff for this commit is also showing a change in line 47 for some reason even though nothing was altered there.

Best,
T.J.